### PR TITLE
Fix problem with STI objects.

### DIFF
--- a/lib/activeadmin/resource_dsl.rb
+++ b/lib/activeadmin/resource_dsl.rb
@@ -5,20 +5,15 @@ module ActiveAdmin
   class ResourceDSL
     def json_editor
       before_save do |object, _args|
-        request_namespace = object.class.name.underscore.tr('/', '_')
-        if params.key? request_namespace
-          object.class.columns_hash.select { |_key, attr| attr.type.in? [:json, :jsonb] }.keys.each do |key|
-            next unless params[request_namespace].key? key
-            json_data = params[request_namespace][key]
-            data = if json_data == 'null' || json_data.blank?
-                     {}
-                   else
-                     JSON.parse(json_data)
-            end
-            object.attributes = { key => data }
+        object.class.columns_hash.select { |_key, attr| attr.type.in? [:json, :jsonb] }.keys.each do |key|
+          next unless params[resource_request_name].key? key
+          json_data = params[resource_request_name][key]
+          data = if json_data == 'null' || json_data.blank?
+                   {}
+                 else
+                   JSON.parse(json_data)
           end
-        else
-          raise ActionController::ParameterMissing, request_namespace
+          object.attributes = { key => data }
         end
       end
     end


### PR DESCRIPTION
Replace `request_namespace = object.class.name.underscore.tr('/', '_')` with `resource_request_name`.