### PR TITLE
Fix nested associations after a change in 0.10.0

### DIFF
--- a/lib/activeadmin/resource_dsl.rb
+++ b/lib/activeadmin/resource_dsl.rb
@@ -21,6 +21,7 @@ module ActiveAdmin
           nested_klass = object.class.reflect_on_association(_nested_key).class_name.constantize
           nested_klass.columns_hash.select { |_key, attr| attr.type.in? [:json, :jsonb] }.keys.each do |key|
             nested_attributes_with_index.each {|_index, nested_attributes|
+              next unless nested_attributes.respond_to?(:key)
               next unless nested_attributes.key? key
               json_data = nested_attributes[key]
               data = if json_data == 'null' || json_data.blank?

--- a/lib/activeadmin/resource_dsl.rb
+++ b/lib/activeadmin/resource_dsl.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
         object.nested_attributes_options.keys.each {|_nested_key|
           nested_attributes_with_index = params[resource_request_name]["#{_nested_key}_attributes"]
           next if nested_attributes_with_index.nil?
-          nested_klass = _nested_key.to_s.singularize.camelize.constantize
+          nested_klass = object.class.reflect_on_association(_nested_key).class_name.constantize
           nested_klass.columns_hash.select { |_key, attr| attr.type.in? [:json, :jsonb] }.keys.each do |key|
             nested_attributes_with_index.each {|_index, nested_attributes|
               next unless nested_attributes.key? key


### PR DESCRIPTION
Let's say we have a model
```
class User < ApplicationRecord
has_one :logo, class_name: "UsersArea::Logo"
accepts_nested_attributes_for :logo
end
```
In the 0.10.0 it tries to constantize a class based on the association name itsself, which breaks if association name does not correspond directly to the class name. In this example it tries to find class `Logo` instead of `UsersArea::Logo` 

This change seems to have fixed that problem for us at least. It would be great if someone could verify in their project :) 
